### PR TITLE
Application Insight Key not being pulled through from the config

### DIFF
--- a/src/RMWorkflowMigrator.CmdLine/Program.cs
+++ b/src/RMWorkflowMigrator.CmdLine/Program.cs
@@ -287,9 +287,12 @@ namespace Microsoft.ALMRangers.RMWorkflowMigrator.CmdLine
         private static TelemetryClient CreateTelemetryClient(string instrumentationKey, bool noMetrics)
         {
             var configuration = TelemetryConfiguration.CreateDefault();
-            configuration.InstrumentationKey = instrumentationKey;
             configuration.DisableTelemetry = noMetrics;
-            return new TelemetryClient(configuration);
+
+            var telemetryClient = new TelemetryClient(configuration);
+            telemetryClient.InstrumentationKey = ApplicationInsightsKey;
+
+            return telemetryClient;
         }
     }
 }

--- a/src/RMWorkflowMigrator.CmdLine/Program.cs
+++ b/src/RMWorkflowMigrator.CmdLine/Program.cs
@@ -290,7 +290,7 @@ namespace Microsoft.ALMRangers.RMWorkflowMigrator.CmdLine
             configuration.DisableTelemetry = noMetrics;
 
             var telemetryClient = new TelemetryClient(configuration);
-            telemetryClient.InstrumentationKey = ApplicationInsightsKey;
+            telemetryClient.InstrumentationKey = instrumentationKey;
 
             return telemetryClient;
         }


### PR DESCRIPTION
### App Insights Key

Setting the application insights key directly on the telemetry client as apposed to passing it through the config.
